### PR TITLE
Add missing ; to Sources/Ecc/Parser.y

### DIFF
--- a/Sources/Ecc/Parser.y
+++ b/Sources/Ecc/Parser.y
@@ -1080,7 +1080,7 @@ statements
   ;
 statement
   : expression ';' {$$=$1+$2;}
-  | k_switch '(' expression ')' '{' statements '}' {$$=$1+$2+$3+$4+$5+$6+$7}
+  | k_switch '(' expression ')' '{' statements '}' {$$=$1+$2+$3+$4+$5+$6+$7;}
   | k_case case_constant_expression ':' {$$=$1+" "+$2+$3+" ";}
   | '{' statements '}' {$$=$1+$2+$3;}
   | expression '{' statements '}' {$$=$1+$2+$3+$4;}


### PR DESCRIPTION
Seems there is a missing ; in the Parser.y file that have to keep adding in, don't know how you get it to compile without fixing this.
