### PR TITLE
Statistics_internal.h: Incorrect case

### DIFF
--- a/Sources/Engine/Graphics/Gfx_Direct3D_Textures.cpp
+++ b/Sources/Engine/Graphics/Gfx_Direct3D_Textures.cpp
@@ -9,7 +9,7 @@
 
 #include <Engine/Graphics/GfxLibrary.h>
 
-#include <Engine/Base/Statistics_internal.h>
+#include <Engine/Base/Statistics_Internal.h>
 #include <Engine/Math/Functions.h>
 #include <Engine/Graphics/GfxProfile.h>
 

--- a/Sources/Engine/Graphics/Gfx_wrapper.cpp
+++ b/Sources/Engine/Graphics/Gfx_wrapper.cpp
@@ -6,7 +6,7 @@
 #include <Engine/Graphics/ViewPort.h>
 
 #include <Engine/Graphics/GfxProfile.h>
-#include <Engine/Base/Statistics_internal.h>
+#include <Engine/Base/Statistics_Internal.h>
 
 //#include <d3dx8math.h>
 //#pragma comment(lib, "d3dx8.lib")

--- a/Sources/Engine/Graphics/TextureRender.cpp
+++ b/Sources/Engine/Graphics/TextureRender.cpp
@@ -17,5 +17,5 @@
 #include <Engine/Templates/Stock_CtextureData.h>
 #include <Engine/Templates/StaticArray.cpp>
 
-#include <Engine/Base/Statistics_internal.h>
+#include <Engine/Base/Statistics_Internal.h>
 


### PR DESCRIPTION
Statistics_internal.h: Incorrect case as its Statistics_Internal.h on disk.
