### PR TITLE
Added find_package(SDL REQUIRED) to bring in the sdl1.2 libraries

### DIFF
--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -4,6 +4,8 @@ project(SeriousEngine)
 # Set @rpath for Mac OS X shared library install names.
 cmake_policy(SET CMP0042 NEW)
 
+# Needed to find the SDL1.2 library files
+find_package(SDL REQUIRED)
 
 # Set up some sanity stuff...
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
@@ -593,13 +595,13 @@ add_executable(SeriousSam
     SeriousSam/SplashScreen.cpp
     SeriousSam/MainWindow.cpp
 )
-target_link_libraries(SeriousSam SeriousEngine)
+target_link_libraries(SeriousSam ${CMAKE_BINARY_DIR}/libSeriousEngine.a ${SDL_LIBRARY})
 add_dependencies(SeriousSam ParseAllEntities)
 
 add_executable(SeriousSamDedicated
     DedicatedServer/DedicatedServer.cpp
 )
-target_link_libraries(SeriousSamDedicated SeriousEngine)
+target_link_libraries(SeriousSamDedicated ${CMAKE_BINARY_DIR}/libSeriousEngine.a ${SDL_LIBRARY})
 add_dependencies(SeriousSamDedicated ParseAllEntities)
 
 if(MACOSX)


### PR DESCRIPTION
Sources/CMakeLists.txt: Added missing find_packge(SDL REQUIRED) to link in the SDL1.2 libraries via ${SDL_LIBRARY} generate variable

```
and added to the target_link_libraries for SeriousSam and SeriousSamDedicated. I don't know not linking the SDL library was
the intended outcome but SeriousSam* was failing to link to libSeriousEngine.a.
```
