### PR TITLE
Fix libraries load failure due to wrong case for ModEXT.txt

### DIFF
--- a/Sources/Engine/Base/Stream.cpp
+++ b/Sources/Engine/Base/Stream.cpp
@@ -156,7 +156,7 @@ void InitStreams(void)
   }
   // find eventual extension for the mod's dlls
   _strModExt = "";
-  LoadStringVar(CTString("ModExt.txt"), _strModExt);
+  LoadStringVar(CTString("ModEXT.txt"), _strModExt);
 
 
   CPrintF(TRANSV("Loading group files...\n"));

--- a/Sources/Engine/Base/Unix/UnixFileSystem.cpp
+++ b/Sources/Engine/Base/Unix/UnixFileSystem.cpp
@@ -227,7 +227,7 @@ static void calcModExt(char *full, const char *exePath, const char *gamename)
     StrRev(pstrFin);
     strncpy( strDirPath, pstrFin, sizeof(strDirPath)-1);
     strDirPath[sizeof(strDirPath)-1] = 0;
-    strcat(strDirPath, "/ModExt.txt");
+    strcat(strDirPath, "/ModEXT.txt");
 
     if (access(strDirPath, F_OK) == 0)
     {


### PR DESCRIPTION
Libraries such as libGameMPD.so and libEntitiesMPD.so failed to load, because this file did not get read due to the wrong letter case.
