### PR TITLE
This fixes building on x86_64 as it sets proper compile-flags

### DIFF
--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -66,6 +66,10 @@ if(LINUX OR MACOSX)
     endif(DEBUG)
     add_definitions(-pthread)
     add_definitions(-pipe -fsigned-char)
+    add_definitions(-m32)
+    # !!! FIXME: (?) apperently add_definitions doesn't change
+    # !!! FIXME:     CXX Flags too..
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32")
     #CXXFLAGS += -fexceptions -frtti
 endif()
 


### PR DESCRIPTION
If you have a better way to set CXXFLAGS or know why add_definitions only affects only CFLAGS, of course this can be changed.
