### PR TITLE
Building on GNU/kFreeBSD and possibly Hurd

### DIFF
--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -8,7 +8,7 @@ project(SeriousEngine)
 find_package(SDL REQUIRED)
 
 # Set up some sanity stuff...
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME MATCHES "GNU|kFreeBSD")
     SET(LINUX TRUE)
 endif()
 if(APPLE)

--- a/Sources/Engine/Network/CommunicationInterface.cpp
+++ b/Sources/Engine/Network/CommunicationInterface.cpp
@@ -134,8 +134,10 @@ static struct ErrorCode ErrorCodes[] = {
   ERRORCODE(ENODEV            , "ENODEV"),
   ERRORCODE(ECONNRESET        , "ECONNRESET"),
   ERRORCODE(ENOTCONN          , "ENOTCONN"),
-  #if !PLATFORM_MACOSX
+  #ifdef ENOSR
   ERRORCODE(ENOSR             , "ENOSR"),
+  #endif
+  #ifdef ENOPKG
   ERRORCODE(ENOPKG            , "ENOPKG"),
   #endif
 #endif


### PR DESCRIPTION
Hi!  Thanks for your work on the GNU/Linux port.

As an extreme test of code portability, I tried building this on
GNU/kFreeBSD.

With the changes in this pull request, on Debian kfreebsd-i386:
$ sudo apt-get install build-essential cmake nasm libogg-dev libsdl1.2-dev
$ cd Serious-Engine/Sources && ./build-linux.sh

it compiles and links fine!  I didn't try running it yet...

Please consider merging these changes to make it even more portable.
Thanks.
