### PR TITLE
Fix pointer truncation on 64-bit

### DIFF
--- a/Sources/Engine/Sound/SoundObject.cpp
+++ b/Sources/Engine/Sound/SoundObject.cpp
@@ -147,7 +147,7 @@ void CSoundObject::Set3DParameters( FLOAT fFalloff, FLOAT fHotSpot,
       //CPrintF("SET3D: ");
       CEntity *pen = so_penEntity->GetPredictionTail();
       if (pen!=so_penEntity) {
-        pso = (CSoundObject *)( ((UBYTE*)pen) + (int(this)-int(so_penEntity)) );
+        pso = (CSoundObject *)( ((UBYTE*)pen) + (size_t(this)-size_t(so_penEntity)) );
       }
     }
   }
@@ -175,7 +175,7 @@ CSoundObject *CSoundObject::GetPredictionTail(ULONG ulTypeID, ULONG ulEventID)
       // it must not play the sound
       return NULL;
     }
-    SLONG slOffset = int(this)-int(so_penEntity);
+    SLONG slOffset = size_t(this)-size_t(so_penEntity);
 
     ULONG ulCRC;
     CRC_Start(ulCRC);


### PR DESCRIPTION
Use size_t instead of int for arithmetic on pointers, to avoid
truncation on ILP64 architectures (like amd64).

It's still not possible to link yet on amd64 because of the i386
assembly needed by SoundMixer.
