### PR TITLE
Export symbols of main executable to dynamic libs

### DIFF
--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -787,6 +787,8 @@ add_executable(ssam
     SeriousSam/MenuPrinting.cpp
 )
 add_dependencies(ssam ParseEntities)
+# Make symbols in the main executable available to dynamic objects
+set_target_properties(ssam PROPERTIES ENABLE_EXPORTS ON)
 
 # !!! FIXME: this is an option because you have to recompile the entire engine twice.
 # !!! FIXME:  If we can put the engine in a static library and not lose symbols,
@@ -795,6 +797,8 @@ option(BUILD_DEDICATED_SERVER "Compile the dedicated server, too" FALSE)
 if(BUILD_DEDICATED_SERVER)
     add_executable(SeriousSamDedicated ${ENGINE_SRCS} DedicatedServer/DedicatedServer.cpp)
     add_dependencies(SeriousSamDedicated ParseEntities)
+    # Make symbols in the main executable available to dynamic objects
+    set_target_properties(SeriousSamDedicated PROPERTIES ENABLE_EXPORTS ON)
 endif()
 
 if(MACOSX)


### PR DESCRIPTION
Link the main executable with -rdynamic, so that its symbols are
available for dynamic objects (such as libEntitiesMPD.so) to use.

I'm not sure why only I had this problem, and you're not seeing it.

I'm using GNU toolchain in Debian jessie amd64, GCC 4.9.

-rdynamic is quite portable, Clang also understands it since at least
version 3.3.  It should cause no harm to add this in any case?
(this is in inside a cmake if(LINUX) block).

Without -rdynamic, the game would fail to start with:
CUnixDynamicLoader error: Bin/Debug/libEntitiesMPD.so: undefined symbol:
_ZN7CEntity21SetPlacement_internalERK12CPlacement3DRK6MatrixIfLi3ELi3EEi

This refers to a function defined in Engine/Entities/Entity.cpp.o:
CEntity::SetPlacement_internal(CPlacement3D const&, Matrix<float, 3, 3> const&, int)
which _is_ linked into Bin/Debug/ssam, but for me it was not exported
as a dynamic symbol without setting this linker flag.

Thanks again!
