### PR TITLE
Dedicated server

### DIFF
--- a/Sources/DedicatedServer/DedicatedServer.cpp
+++ b/Sources/DedicatedServer/DedicatedServer.cpp
@@ -101,7 +101,7 @@ void LimitFrameRate(void)
   TIME tmCurrentDelta = (tvNow-tvLast).GetSeconds();
 
   // limit maximum frame rate
-  ded_iMaxFPS = ClampDn( ded_iMaxFPS,   1L);
+  ded_iMaxFPS = ClampDn( ded_iMaxFPS, 1);
   TIME tmWantedDelta  = 1.0f / ded_iMaxFPS;
   if( tmCurrentDelta<tmWantedDelta)
     _pTimer->Sleep( (DWORD) ((tmWantedDelta-tmCurrentDelta)*1000.0f) );

--- a/Sources/DedicatedServer/DedicatedServer.cpp
+++ b/Sources/DedicatedServer/DedicatedServer.cpp
@@ -39,6 +39,10 @@ CTString sam_strGameName = "serioussam";
 
 CTimerValue _tvLastLevelEnd((__int64) -1);
 
+// Not used; dummy declaration only needed by
+// Engine/Base/ErrorReporting.o
+HWND _hwndMain = NULL;
+
 void InitializeGame(void)
 {
   #ifdef STATICALLY_LINKED


### PR DESCRIPTION
I needed these fixes to compile and link DedicatedServer.

I added the dummy _hwndMain because
Engine/Base/ErrorReporting.cpp refers to an
extern HWND _hwndMain
which gives me a fatal linker error because no object declared it.

CMakeFiles/SeriousSamDedicated.dir/Engine/Base/ErrorReporting.cpp.o: In function `FatalError(char const*, ...)':
Sources/Engine/Base/ErrorReporting.cpp:62: undefined reference to`_hwndMain'
Sources/Engine/Base/ErrorReporting.cpp:63: undefined reference to `_hwndMain'
CMakeFiles/SeriousSamDedicated.dir/Engine/Base/ErrorReporting.cpp.o: In function`WarningMessage(char const_, ...)':
Sources/Engine/Base/ErrorReporting.cpp:118: undefined reference to `_hwndMain'
CMakeFiles/SeriousSamDedicated.dir/Engine/Base/ErrorReporting.cpp.o: In function`InfoMessage(char const_, ...)':
Sources/Engine/Base/ErrorReporting.cpp:139: undefined reference to `_hwndMain'
CMakeFiles/SeriousSamDedicated.dir/Engine/Base/ErrorReporting.cpp.o: In function`YesNoMessage(char const*, ...)':
Sources/Engine/Base/ErrorReporting.cpp:173: undefined reference to `_hwndMain'
collect2: error: ld returned 1 exit status

Declaring it and assigning NULL, causes the SDL functions to fail
quietly.  Perhaps DedicatedServer should stop linking this file someday
(because it requires linking with SDL).
