### PR TITLE
Only use <malloc.h> on Win32; increase SDL sound buffer

### DIFF
--- a/Sources/Ecc/StdH.h
+++ b/Sources/Ecc/StdH.h
@@ -21,7 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <stdarg.h>
 #include <math.h>
 
-#if !defined(PLATFORM_MACOSX) && !defined(PLATFORM_FREEBSD)
+#ifdef PLATFORM_WIN32
 #include <malloc.h>
 #endif
 

--- a/Sources/Engine/Engine.h
+++ b/Sources/Engine/Engine.h
@@ -38,12 +38,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <search.h>   // for qsort
 #include <float.h>    // for FPU control
 
-#if !defined(PLATFORM_MACOSX) && !defined(PLATFORM_FREEBSD)
-#include <malloc.h>
-#endif
-
 /* rcg10042001 !!! FIXME: Move these somewhere. */
 #if (defined PLATFORM_WIN32)
+#include <malloc.h>
 #include <conio.h>
 #include <crtdbg.h>
 #include <winsock2.h>

--- a/Sources/Engine/Sound/SoundLibrary.cpp
+++ b/Sources/Engine/Sound/SoundLibrary.cpp
@@ -258,7 +258,7 @@ static BOOL StartUp_SDLaudio( CSoundLibrary &sl, BOOL bReport=TRUE)
   }
 
   sdl_silence = obtained.silence;
-  sdl_backbuffer_allocation = (obtained.size * 2);
+  sdl_backbuffer_allocation = (obtained.size * 4);
   sdl_backbuffer = (Uint8 *)AllocMemory(sdl_backbuffer_allocation);
   sdl_backbuffer_remain = 0;
   sdl_backbuffer_pos = 0;

--- a/Sources/Engine/StdH.h
+++ b/Sources/Engine/StdH.h
@@ -27,11 +27,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <search.h>   // for qsort
 #include <float.h>    // for FPU control
 
-#if !defined(PLATFORM_MACOSX) && !defined(PLATFORM_FREEBSD)
-#include <malloc.h>
-#endif
-
 #ifdef PLATFORM_WIN32
+#include <malloc.h>
 #include <conio.h>
 #include <crtdbg.h>
 #include <winsock2.h>


### PR DESCRIPTION
Everyone except for Windows should use `<stdlib.h>` instead of `<malloc.h>`.

Audio output sounded crappy on my system, it improved a lot after I doubled the internal buffer size.
