### PR TITLE
Some 64bit improvements, lots of 64bit TODOs/STUBBED()

### DIFF
--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -9,6 +9,9 @@ option(USE_SYSTEM_SDL2 "Use system wide sdl2 libraries/includes" On)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 
+# ssam expects the libs to be in Debug/
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/Debug)
+
 # Use systemwide SDL2 or custom build
 # RAKE!: Find a way to use their custom built library if
 # they want to use that instead or if their system only
@@ -110,6 +113,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_definitions(-Wno-switch)
     add_definitions(-Wno-tautological-undefined-compare)
     add_definitions(-Wno-c++11-compat-deprecated-writable-strings)
+    add_definitions(-Wno-logical-op-parentheses)
 endif()
 
 # !!! FIXME: you currently need this, but I'd like to flip this to not use

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -114,6 +114,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_definitions(-Wno-tautological-undefined-compare)
     add_definitions(-Wno-c++11-compat-deprecated-writable-strings)
     add_definitions(-Wno-logical-op-parentheses)
+    MESSAGE(WARNING "reenable -Wlogical-op-parentheses some day!")
 endif()
 
 # !!! FIXME: you currently need this, but I'd like to flip this to not use

--- a/Sources/Engine/Base/CRC.h
+++ b/Sources/Engine/Base/CRC.h
@@ -44,6 +44,18 @@ inline void CRC_AddLONG( ULONG &ulCRC, ULONG ul)
   CRC_AddBYTE(ulCRC, UBYTE(ul>> 0));
 };
 
+inline void CRC_AddLONGLONG( ULONG &ulCRC, __uint64 x)
+{
+  CRC_AddBYTE(ulCRC, UBYTE(x>>56));
+  CRC_AddBYTE(ulCRC, UBYTE(x>>48));
+  CRC_AddBYTE(ulCRC, UBYTE(x>>40));
+  CRC_AddBYTE(ulCRC, UBYTE(x>>32));
+  CRC_AddBYTE(ulCRC, UBYTE(x>>24));
+  CRC_AddBYTE(ulCRC, UBYTE(x>>16));
+  CRC_AddBYTE(ulCRC, UBYTE(x>> 8));
+  CRC_AddBYTE(ulCRC, UBYTE(x>> 0));
+}
+
 inline void CRC_AddFLOAT(ULONG &ulCRC, FLOAT f)
 {
   CRC_AddLONG(ulCRC, *(ULONG*)&f);

--- a/Sources/Engine/Base/Shell.cpp
+++ b/Sources/Engine/Base/Shell.cpp
@@ -704,6 +704,7 @@ INDEX CShell::GetINDEX(const CTString &strName)
     return -666;
   } 
   // get it
+  STUBBED("64-bit issue"); // the return value is used as a pointer a lot!
   return *(INDEX*)pss->ss_pvValue;
 }
 

--- a/Sources/Engine/Base/Shell.cpp
+++ b/Sources/Engine/Base/Shell.cpp
@@ -148,6 +148,7 @@ CShell::CShell(void)
 {
   // allocate undefined symbol
   _shell_istUndeclared = _shell_ast.Allocate();
+  pwoCurrentWorld = NULL;
 };
 CShell::~CShell(void)
 {
@@ -704,7 +705,6 @@ INDEX CShell::GetINDEX(const CTString &strName)
     return -666;
   } 
   // get it
-  STUBBED("64-bit issue"); // the return value is used as a pointer a lot!
   return *(INDEX*)pss->ss_pvValue;
 }
 

--- a/Sources/Engine/Base/Shell.h
+++ b/Sources/Engine/Base/Shell.h
@@ -33,6 +33,8 @@ public:
   CTCriticalSection sh_csShell; // critical section for access to shell data
   CDynamicArray<CShellSymbol> sh_assSymbols;  // all defined symbols
 
+  CWorld* pwoCurrentWorld;
+
   // Get a shell symbol by its name.
   CShellSymbol *GetSymbol(const CTString &strName, BOOL bDeclaredOnly);
   // Report error in shell script processing.
@@ -59,13 +61,23 @@ public:
   // get/set symbols
   FLOAT GetFLOAT(const CTString &strName);
   void SetFLOAT(const CTString &strName, FLOAT fValue);
-  INDEX GetINDEX(const CTString &strName); // FIXME DG: maybe this should return size_t or uintptr_t? return value is casted to ptr all the time!
+  INDEX GetINDEX(const CTString &strName);
   void SetINDEX(const CTString &strName, INDEX iValue);
   CTString GetString(const CTString &strName);
   void SetString(const CTString &strName, const CTString &strValue);
 
   CTString GetValue(const CTString &strName);
   void SetValue(const CTString &strName, const CTString &strValue);
+
+  void SetCurrentWorld(CWorld* pwo)
+  {
+    pwoCurrentWorld = pwo;
+  }
+
+  CWorld* GetCurrentWorld(void)
+  {
+    return pwoCurrentWorld;
+  }
 };
 
 // pointer to global shell object

--- a/Sources/Engine/Base/Shell.h
+++ b/Sources/Engine/Base/Shell.h
@@ -59,7 +59,7 @@ public:
   // get/set symbols
   FLOAT GetFLOAT(const CTString &strName);
   void SetFLOAT(const CTString &strName, FLOAT fValue);
-  INDEX GetINDEX(const CTString &strName);
+  INDEX GetINDEX(const CTString &strName); // FIXME DG: maybe this should return size_t or uintptr_t? return value is casted to ptr all the time!
   void SetINDEX(const CTString &strName, INDEX iValue);
   CTString GetString(const CTString &strName);
   void SetString(const CTString &strName, const CTString &strValue);

--- a/Sources/Engine/Base/Types.h
+++ b/Sources/Engine/Base/Types.h
@@ -182,11 +182,8 @@ typedef unsigned int        UINT;
     inline ULONG _rotl(ULONG ul, int bits)
     {
         #if (defined USE_PORTABLE_C)
-            // This is not fast at all, but it works.
-            for (int i = 0; i < bits; i++)
-                ul = ( (ul << 1) | ((ul & 0x80000000) >> 31) );
-            return(ul);
-
+            // DG: according to http://blog.regehr.org/archives/1063 this is fast
+            return (ul<<bits) | (ul>>(-bits&31));
         #elif (defined __GNU_INLINE__)
             // This, on the other hand, is wicked fast.  :)
             __asm__ __volatile__ (

--- a/Sources/Engine/Base/Types.h
+++ b/Sources/Engine/Base/Types.h
@@ -61,6 +61,37 @@ typedef unsigned int        UINT;
   #define PLATFORM_LITTLEENDIAN 1
 #endif
 
+#ifdef PLATFORM_WIN32
+  #ifdef _WIN64
+    #define PLATFORM_64BIT 1
+  #else
+    #define PLATFORM_32BIT 1
+  #endif
+#else
+  // AFAIK there were versions of MSVC where UINTPTR_MAX was incorrect,
+  // so I use different code for Windows above
+  #include <stdint.h> // UINTPTR_MAX
+  #ifdef UINTPTR_MAX
+    #if UINTPTR_MAX == 0xffffffffuL
+      #define PLATFORM_32BIT 1
+    #elif UINTPTR_MAX == 0xffffffffffffffffuLL
+      #define PLATFORM_64BIT 1
+    #else
+      #error WTF, your system seems to be neither 32bit nor 64bit?!
+    #endif
+  #else
+    #error Your system does not provide UINTPRT_MAX, find another way!
+  #endif
+
+  #if UINTPTR_MAX != SIZE_MAX
+    // the code uses size_t to store pointers all over the place, so if size_t and uintptr_t
+    // don't have the same size on your system, you're in real trouble.
+    // (before panicking however make sure your headers don't just contain bullshit values for UINTPTR_MAX or SIZE_MAX)
+    #error Seems like on your system sizeof(size_t) != sizeof(uintptr_t) - that is *very* bad.
+  #endif
+
+#endif
+
 // Mac symbols have an underscore prepended...
 #if PLATFORM_MACOSX
   #define ASMSYM(x) "_" #x

--- a/Sources/Engine/Brushes/BrushPolygon.cpp
+++ b/Sources/Engine/Brushes/BrushPolygon.cpp
@@ -84,7 +84,7 @@ void CBrushPolygon::CreateBSPPolygon(BSPPolygon<DOUBLE, 3> &bspo)
 
   // set the plane of the bsp polygon
   ((DOUBLEplane3D &)bspo) = *brpo.bpo_pbplPlane->bpl_ppldPreciseAbsolute;
-  bspo.bpo_ulPlaneTag = (ULONG)brpo.bpo_pbscSector->bsc_abplPlanes.Index(brpo.bpo_pbplPlane);
+  bspo.bpo_ulPlaneTag = (size_t)brpo.bpo_pbscSector->bsc_abplPlanes.Index(brpo.bpo_pbplPlane);
 
   // create the array of edges in the bsp polygon
   INDEX ctEdges = brpo.bpo_abpePolygonEdges.Count();
@@ -109,7 +109,7 @@ void CBrushPolygon::CreateBSPPolygonNonPrecise(BSPPolygon<DOUBLE, 3> &bspo)
 
   // set the plane of the bsp polygon
   ((DOUBLEplane3D &)bspo) = FLOATtoDOUBLE(brpo.bpo_pbplPlane->bpl_plAbsolute);
-  bspo.bpo_ulPlaneTag = (ULONG)brpo.bpo_pbscSector->bsc_abplPlanes.Index(brpo.bpo_pbplPlane);
+  bspo.bpo_ulPlaneTag = (size_t)brpo.bpo_pbscSector->bsc_abplPlanes.Index(brpo.bpo_pbplPlane);
   // calculate offset for points
   DOUBLE3D vOffset = FLOATtoDOUBLE(((FLOAT3D&)brpo.bpo_pbplPlane->bpl_plAbsolute))*-fOffset;
   // offset the plane

--- a/Sources/Engine/Graphics/DrawPort.cpp
+++ b/Sources/Engine/Graphics/DrawPort.cpp
@@ -221,8 +221,11 @@ ULONG CDrawPort::GetID(void)
 {
   ULONG ulCRC;
   CRC_Start(   ulCRC);
-  STUBBED("64-bit issue");
+#ifdef PLATFORM_64BIT
+  CRC_AddLONGLONG( ulCRC, (__uint64)(size_t)dp_Raster);
+#else
   CRC_AddLONG( ulCRC, (ULONG)(size_t)dp_Raster);
+#endif
   CRC_AddLONG( ulCRC, (ULONG)dp_MinI);
   CRC_AddLONG( ulCRC, (ULONG)dp_MinJ);
   CRC_AddLONG( ulCRC, (ULONG)dp_MaxI);

--- a/Sources/Engine/Graphics/ImageInfo.cpp
+++ b/Sources/Engine/Graphics/ImageInfo.cpp
@@ -75,6 +75,7 @@ static __forceinline CTStream &operator>>(CTStream &strm, PCXHeader &t) {
   strm>>t.HscreenSize;
   strm>>t.VscreenSize;
   strm.Read_t(t.Filler, sizeof (t.Filler));
+  return strm;
 }
 
 static __forceinline CTStream &operator<<(CTStream &strm, const PCXHeader &t) {
@@ -96,6 +97,7 @@ static __forceinline CTStream &operator<<(CTStream &strm, const PCXHeader &t) {
   strm<<t.HscreenSize;
   strm<<t.VscreenSize;
   strm.Write_t(t.Filler, sizeof (t.Filler));
+  return strm;
 }
 
 // TARGA header structure

--- a/Sources/Engine/Graphics/Texture.cpp
+++ b/Sources/Engine/Graphics/Texture.cpp
@@ -1367,7 +1367,8 @@ void CTextureData::SetAsCurrent( INDEX iFrameNo/*=0*/, BOOL bForceUpload/*=FALSE
       for( INDEX iFr=0; iFr<td_ctFrames; iFr++)
       { // determine frame offset and upload texture frame
         ULONG *pulCurrentFrame = td_pulFrames + (iFr * td_slFrameSize/BYTES_PER_TEXEL);
-        gfxSetTexture( ((ULONG*)td_ulObject)[iFr], td_tpLocal);
+        STUBBED("64-bit issue");
+        gfxSetTexture( ((ULONG*)td_ulObject)[iFr], td_tpLocal); // FIXME DG: use that union properly or something?!
         gfxUploadTexture( pulCurrentFrame, pixWidth, pixHeight, td_ulInternalFormat, bNoDiscard);
       }
     } else {
@@ -1401,11 +1402,13 @@ void CTextureData::SetAsCurrent( INDEX iFrameNo/*=0*/, BOOL bForceUpload/*=FALSE
     // must reset local texture parameters for each frame of animated texture
     for( INDEX iFr=0; iFr<td_ctFrames; iFr++) {
       td_tpLocal.Clear();
-      gfxSetTexture( ((ULONG*)td_ulObject)[iFr], td_tpLocal);
+      STUBBED("64-bit issue");
+      gfxSetTexture( ((ULONG*)td_ulObject)[iFr], td_tpLocal); // FIXME DG: use that union properly or something?!
     }
   } 
   // set corresponding probe or texture frame as current
   ULONG ulTexObject = td_ulObject; // single-frame
+  STUBBED("64-bit issue"); // FIXME DG: same here...
   if( td_ctFrames>1) ulTexObject = ((ULONG*)td_ulObject)[iFrameNo]; // animation
   if( bUseProbe) {
     // set probe if burst value doesn't allow real texture

--- a/Sources/Engine/Graphics/Texture.cpp
+++ b/Sources/Engine/Graphics/Texture.cpp
@@ -1312,7 +1312,7 @@ void CTextureData::SetAsCurrent( INDEX iFrameNo/*=0*/, BOOL bForceUpload/*=FALSE
 
   // if not already generated, generate bind number(s) and force upload
   const PIX pixTextureSize = pixWidth*pixHeight;
-  if( td_ulObject==NONE)
+  if((td_ctFrames>1 && td_pulObjects==NULL) || td_ulObject==NONE)
   {
     // check whether frames are present
     ASSERT( td_pulFrames!=NULL && td_pulFrames[0]!=0xDEADBEEF); 
@@ -1367,8 +1367,7 @@ void CTextureData::SetAsCurrent( INDEX iFrameNo/*=0*/, BOOL bForceUpload/*=FALSE
       for( INDEX iFr=0; iFr<td_ctFrames; iFr++)
       { // determine frame offset and upload texture frame
         ULONG *pulCurrentFrame = td_pulFrames + (iFr * td_slFrameSize/BYTES_PER_TEXEL);
-        STUBBED("64-bit issue");
-        gfxSetTexture( ((ULONG*)td_ulObject)[iFr], td_tpLocal); // FIXME DG: use that union properly or something?!
+        gfxSetTexture( td_pulObjects[iFr], td_tpLocal);
         gfxUploadTexture( pulCurrentFrame, pixWidth, pixHeight, td_ulInternalFormat, bNoDiscard);
       }
     } else {
@@ -1393,7 +1392,7 @@ void CTextureData::SetAsCurrent( INDEX iFrameNo/*=0*/, BOOL bForceUpload/*=FALSE
       td_pulFrames = NULL;
     }
     // done uploading
-    ASSERT( td_ulObject!=NONE);
+    ASSERT((td_ctFrames>1 && td_pulObjects!=NULL) || td_ulObject!=NONE);
     return;
   }
 
@@ -1402,14 +1401,11 @@ void CTextureData::SetAsCurrent( INDEX iFrameNo/*=0*/, BOOL bForceUpload/*=FALSE
     // must reset local texture parameters for each frame of animated texture
     for( INDEX iFr=0; iFr<td_ctFrames; iFr++) {
       td_tpLocal.Clear();
-      STUBBED("64-bit issue");
-      gfxSetTexture( ((ULONG*)td_ulObject)[iFr], td_tpLocal); // FIXME DG: use that union properly or something?!
+      gfxSetTexture( td_pulObjects[iFr], td_tpLocal); // FIXME DG: use that union properly or something?!
     }
   } 
   // set corresponding probe or texture frame as current
-  ULONG ulTexObject = td_ulObject; // single-frame
-  STUBBED("64-bit issue"); // FIXME DG: same here...
-  if( td_ctFrames>1) ulTexObject = ((ULONG*)td_ulObject)[iFrameNo]; // animation
+  ULONG ulTexObject = (td_ctFrames>1) ? td_pulObjects[iFrameNo] : td_ulObject; // single-frame or animation
   if( bUseProbe) {
     // set probe if burst value doesn't allow real texture
     if( _pGfx->gl_slAllowedUploadBurst<0) {  
@@ -1440,17 +1436,22 @@ void CTextureData::Unbind(void)
   // reset mark
   td_tvLastDrawn = (__int64) 0;
 
-  // only if bound
-  if( td_ulObject==NONE) {
-    ASSERT( td_ulProbeObject==NONE);
-    return;
-  }
   // free frame number(s)
   if( td_ctFrames>1) { // animation
+    // only if bound
+    if( td_pulObjects == NULL ||  td_pulObjects[0]==NONE) {
+      ASSERT( td_pulObjects == NULL || td_pulObjects[0]==NONE);
+      return;
+    }
     for( INDEX iFrame=0; iFrame<td_ctFrames; iFrame++) gfxDeleteTexture( td_pulObjects[iFrame]);
     FreeMemory( td_pulObjects);
     td_pulObjects = NULL;
   } else { // single-frame
+    // only if bound
+    if( td_ulObject==NONE) {
+      ASSERT( td_ulProbeObject==NONE);
+      return;
+    }
     gfxDeleteTexture(td_ulObject);
   }
   // delete probe texture, too
@@ -1725,8 +1726,7 @@ BOOL CTextureData::IsAutoFreed(void)
 SLONG CTextureData::GetUsedMemory(void)
 {
   // readout texture object
-  ULONG ulTexObject = td_ulObject;
-  if( td_ctFrames>1) ulTexObject = td_pulObjects[0];
+  ULONG ulTexObject = (td_ctFrames>1) ? td_pulObjects[0] : td_ulObject;
 
   // add structure size and anim block size
   SLONG slUsed = sizeof(*this) + CAnimData::GetUsedMemory()-sizeof(CAnimData);

--- a/Sources/Engine/Math/Functions.h
+++ b/Sources/Engine/Math/Functions.h
@@ -313,7 +313,10 @@ inline FLOAT NormByteToFloat( const ULONG ul)
 inline SLONG FloatToInt( FLOAT f)
 {
 #if defined(__arm__) || defined(USE_PORTABLE_C)
-  return((SLONG) (f + 0.5f));  /* best of luck to you. */
+  // round to nearest by adding/subtracting 0.5 (depending on f pos/neg) before converting to SLONG
+  float addToRound = 0.5f;
+  copysignf(addToRound, f); // copy f's signbit to addToRound => if f<0 then addToRound = -addToRound
+  return((SLONG) (f + addToRound));
 
 #elif (defined __MSVC_INLINE__)
   SLONG slRet;
@@ -341,8 +344,7 @@ inline SLONG FloatToInt( FLOAT f)
 // log base 2 of any float numero
 inline FLOAT Log2( FLOAT f) {
 #if (defined USE_PORTABLE_C) || defined(__arm__)
-  // !!! FIXME: What's wrong with log2()?
-  return (FLOAT)(log10(f)*3.321928094887);  // log10(x)/log10(2)
+  return log2f(f);
 
 #elif (defined __MSVC_INLINE__)
   FLOAT fRet;
@@ -376,6 +378,11 @@ inline FLOAT Log2( FLOAT f) {
 inline SLONG FastLog2( SLONG x)
 {
 #if (defined USE_PORTABLE_C)
+#ifdef __GNUC__
+  if(x == 0) return 0; // __builtin_clz() is undefined for 0
+  int numLeadingZeros  = __builtin_clz(x);
+  return 31 - numLeadingZeros;
+#else
   register SLONG val = x;
   register SLONG retval = 31;
   while (retval > 0)
@@ -386,6 +393,7 @@ inline SLONG FastLog2( SLONG x)
   }
 
   return 0;
+#endif
 
 #elif (defined __MSVC_INLINE__)
   SLONG slRet;
@@ -409,6 +417,7 @@ inline SLONG FastLog2( SLONG x)
 #endif
 }
 
+/* DG: function is unused => doesn't matter that portable implementation is not optimal :)
 // returns log2 of first larger value that is a power of 2
 inline SLONG FastMaxLog2( SLONG x)
 { 
@@ -443,6 +452,7 @@ printf("CHECK THIS: %s:%d\n", __FILE__, __LINE__);
   #error Fill this in for your platform.
 #endif
 }
+*/
 
 
 

--- a/Sources/Engine/Math/Object3D_CSG.cpp
+++ b/Sources/Engine/Math/Object3D_CSG.cpp
@@ -323,16 +323,14 @@ void CObjectCSG::PolygonEdgesToBSPEdges(
     // if it is reversed
     if (ope.ope_Backward) {
       // add bsp edge with reverse vertices
-      STUBBED("64-bit issue"); // we're casting ope.ope_Edge to a 32-bit value. Code really only cares if this is zero or !zero, but one could totally have a non-NULL 64-bit pointer that truncates down to zero!
       abed[iEdge] = DOUBLEbspedge3D(*ope.ope_Edge->oed_Vertex1,
-        *ope.ope_Edge->oed_Vertex0, (ULONG)(size_t)ope.ope_Edge);
+        *ope.ope_Edge->oed_Vertex0, (size_t)ope.ope_Edge);
 
     // if it is not reversed
     } else{
       // add bsp edge with normal vertices
-      STUBBED("64-bit issue"); // we're casting ope.ope_Edge to a 32-bit value. Code really only cares if this is zero or !zero, but one could totally have a non-NULL 64-bit pointer that truncates down to zero!
       abed[iEdge] = DOUBLEbspedge3D(*ope.ope_Edge->oed_Vertex0,
-        *ope.ope_Edge->oed_Vertex1, (ULONG)(size_t)ope.ope_Edge);
+        *ope.ope_Edge->oed_Vertex1, (size_t)ope.ope_Edge);
     }
   }
 
@@ -544,8 +542,7 @@ void CObjectCSG::DoCSGSplitting(
         oc_popoPortalB1B2 = NULL;
 
         // create a bsp polygon from first temporary array
-        STUBBED("64-bit issue");
-        DOUBLEbsppolygon3D bpoA(*itopoA->opo_Plane, abedRemaining, (ULONG)(size_t)itopoA->opo_Plane);
+        DOUBLEbsppolygon3D bpoA(*itopoA->opo_Plane, abedRemaining, (size_t)itopoA->opo_Plane);
 
         // create a BSP cutter for B's sector BSP and A's polygon
         DOUBLEbspcutter3D bcCutter(bpoA, *itoscB->osc_BSPTree.bt_pbnRoot);

--- a/Sources/Engine/Math/ObjectSector.cpp
+++ b/Sources/Engine/Math/ObjectSector.cpp
@@ -1844,8 +1844,7 @@ void CObjectSector::CreateBSP(void)
 
     // copy the plane
     (DOUBLEplane3D &)bpo = *opo.opo_Plane;
-    STUBBED("64-bit issue");
-    bpo.bpo_ulPlaneTag = (ULONG)(size_t)opo.opo_Plane;
+    bpo.bpo_ulPlaneTag = (size_t)opo.opo_Plane;
 
     // get count of edges in this polygon
     const INDEX ctEdges = opo.opo_PolygonEdges.Count();
@@ -1860,13 +1859,11 @@ void CObjectSector::CreateBSP(void)
       // if the edge is reversed
       if(ope.ope_Backward) {
         // add bsp edge with reversed vertices
-        STUBBED("64-bit issue");
-        pbed[iEdge] = DOUBLEbspedge3D(*oed.oed_Vertex1, *oed.oed_Vertex0, (ULONG)(size_t)&oed);
+        pbed[iEdge] = DOUBLEbspedge3D(*oed.oed_Vertex1, *oed.oed_Vertex0, (size_t)&oed);
       // otherwise
       } else {
         // add normal bsp edge
-        STUBBED("64-bit issue");
-        pbed[iEdge] = DOUBLEbspedge3D(*oed.oed_Vertex0, *oed.oed_Vertex1, (ULONG)(size_t)&oed);
+        pbed[iEdge] = DOUBLEbspedge3D(*oed.oed_Vertex0, *oed.oed_Vertex1, (size_t)&oed);
       }
     }
     opo.opo_PolygonEdges.Unlock();

--- a/Sources/Engine/Models/Model.cpp
+++ b/Sources/Engine/Models/Model.cpp
@@ -481,7 +481,7 @@ ModelTextureVertex::ModelTextureVertex(void)
 //------------------------------------------ WRITE
 void ModelPolygonVertex::Write_t( CTStream *pFile)  // throw char *
 {
-  STUBBED("64-bit issue");
+  STUBBED("64-bit issue"); // DG: probably ok, because PtrToIndices() should have been called before this
   (*pFile) << (INDEX) (size_t) mpv_ptvTransformedVertex;
   (*pFile) << (INDEX) (size_t) mpv_ptvTextureVertex;
 }
@@ -490,7 +490,7 @@ void ModelPolygonVertex::Read_t( CTStream *pFile) // throw char *
 {
   INDEX itmp;
 
-  STUBBED("64-bit issue");
+  STUBBED("64-bit issue"); // DG: probably ok, because IndicesToPtrs() should be called afterwards
   (*pFile) >> itmp;
   mpv_ptvTransformedVertex = (struct TransformedVertexData *) (size_t) itmp;
   (*pFile) >> itmp;
@@ -1040,14 +1040,14 @@ void CModelData::PtrsToIndices()
           if( it2.Current().mpv_ptvTransformedVertex == &md_TransformedVertices[ j])
             break;
         }
-        it2.Current().mpv_ptvTransformedVertex = (struct TransformedVertexData *) j;
+        it2.Current().mpv_ptvTransformedVertex = (struct TransformedVertexData *)(size_t)j;
 
         for( j=0; j<md_MipInfos[ i].mmpi_TextureVertices.Count(); j++)
         {
           if( it2.Current().mpv_ptvTextureVertex == &md_MipInfos[ i].mmpi_TextureVertices[ j])
             break;
         }
-        it2.Current().mpv_ptvTextureVertex = (ModelTextureVertex *) j;
+        it2.Current().mpv_ptvTextureVertex = (ModelTextureVertex *)(size_t)j;
       }
     }
   }
@@ -1068,10 +1068,10 @@ void CModelData::IndicesToPtrs()
       FOREACHINSTATICARRAY(it1.Current().mp_PolygonVertices, ModelPolygonVertex, it2)
       {
         struct ModelPolygonVertex * pMPV = &it2.Current();
-        STUBBED("64-bit issue");
+        STUBBED("64-bit issue"); // DG: probably ok, the pointers really contain indices from PtrToIndices()
         j = (INDEX) (size_t) it2.Current().mpv_ptvTransformedVertex;
         it2.Current().mpv_ptvTransformedVertex = &md_TransformedVertices[ j];
-        STUBBED("64-bit issue");
+        STUBBED("64-bit issue"); // DG: probably ok, the pointers really contain indices from PtrToIndices()
         j = (INDEX) (size_t) it2.Current().mpv_ptvTextureVertex;
         it2.Current().mpv_ptvTextureVertex = &md_MipInfos[ i].mmpi_TextureVertices[ j];
       }

--- a/Sources/Engine/Network/Network.cpp
+++ b/Sources/Engine/Network/Network.cpp
@@ -254,6 +254,7 @@ extern void CacheShadows(void)
 {
   // mute all sounds
   _pSound->Mute();
+  STUBBED("64-bit issue"); // GetINDEX() returns int32!
   CWorld *pwo = (CWorld*)_pShell->GetINDEX("pwoCurrentWorld");
   if( pwo!=NULL) {
     pwo->wo_baBrushes.CacheAllShadowmaps();
@@ -522,6 +523,7 @@ static void StockInfo(void)
   INDEX ctEntities=0, ctShadowLayers=0, ctPolys=0,    ctPlanes=0,   ctEdges=0,    ctVertices=0, ctSectors=0;
   SLONG slEntBytes=0, slLyrBytes=0,     slPlyBytes=0, slPlnBytes=0, slEdgBytes=0, slVtxBytes=0, slSecBytes=0;
   SLONG slCgrBytes=0;
+  STUBBED("64-bit issue"); // GetINDEX() returns int32!
   CWorld *pwo = (CWorld*)_pShell->GetINDEX("pwoCurrentWorld");
 
   if( pwo!=NULL)

--- a/Sources/Engine/Network/Network.cpp
+++ b/Sources/Engine/Network/Network.cpp
@@ -86,8 +86,6 @@ BOOL _bTempNetwork = FALSE;  // set while using temporary second network object
 extern BOOL con_bCapture;
 extern CTString con_strCapture;
 
-static CWorld *_pwoCurrentWorld = NULL;
-
 static FLOAT _bStartDemoRecordingNextTime = FALSE;
 static FLOAT _bStopDemoRecordingNextTime = FALSE;
 static INDEX dem_iRecordedNumber = 0;
@@ -254,8 +252,7 @@ extern void CacheShadows(void)
 {
   // mute all sounds
   _pSound->Mute();
-  STUBBED("64-bit issue"); // GetINDEX() returns int32!
-  CWorld *pwo = (CWorld*)_pShell->GetINDEX("pwoCurrentWorld");
+  CWorld *pwo = _pShell->GetCurrentWorld();
   if( pwo!=NULL) {
     pwo->wo_baBrushes.CacheAllShadowmaps();
     CPrintF( TRANS("All shadows recached"));
@@ -523,8 +520,7 @@ static void StockInfo(void)
   INDEX ctEntities=0, ctShadowLayers=0, ctPolys=0,    ctPlanes=0,   ctEdges=0,    ctVertices=0, ctSectors=0;
   SLONG slEntBytes=0, slLyrBytes=0,     slPlyBytes=0, slPlnBytes=0, slEdgBytes=0, slVtxBytes=0, slSecBytes=0;
   SLONG slCgrBytes=0;
-  STUBBED("64-bit issue"); // GetINDEX() returns int32!
-  CWorld *pwo = (CWorld*)_pShell->GetINDEX("pwoCurrentWorld");
+  CWorld *pwo = _pShell->GetCurrentWorld();
 
   if( pwo!=NULL)
   {
@@ -899,7 +895,6 @@ void CNetworkLibrary::Init(const CTString &strGameID)
   _pShell->DeclareSymbol("persistent user CTString ga_strMSLegacy;", (void *)&ga_strMSLegacy);
   _pShell->DeclareSymbol("persistent user INDEX ga_bMSLegacy;", (void *)&ga_bMSLegacy);
 
-  _pShell->DeclareSymbol("INDEX pwoCurrentWorld;", (void *)&_pwoCurrentWorld);
 }
 
 /*
@@ -1041,8 +1036,7 @@ void CNetworkLibrary::StartPeerToPeer_t(const CTString &strSessionName,
     throw;
   }
   // remember the world pointer
-  STUBBED("64-bit issue");
-  _pShell->SetINDEX("pwoCurrentWorld", (INDEX)(size_t)&ga_World);
+  _pShell->SetCurrentWorld(&ga_World);
 
   SetProgressDescription(TRANS("starting server"));
   CallProgressHook_t(0.0f);
@@ -1279,8 +1273,7 @@ void CNetworkLibrary::JoinSession_t(const CNetworkSession &nsSesssion, INDEX ctL
   }
 
   // remember the world pointer
-  STUBBED("64-bit issue");
-  _pShell->SetINDEX("pwoCurrentWorld", (INDEX)(size_t)&ga_World);
+  _pShell->SetCurrentWorld(&ga_World);
 
   // eventually cache all shadowmaps in world (memory eater!)
   if( shd_bCacheAll) ga_World.wo_baBrushes.CacheAllShadowmaps();
@@ -1352,8 +1345,7 @@ void CNetworkLibrary::StartDemoPlay_t(const CTFileName &fnDemo)  // throw char *
   _bNeedPretouch = TRUE;
 
   // remember the world pointer
-  STUBBED("64-bit issue");
-  _pShell->SetINDEX("pwoCurrentWorld", (INDEX)(size_t)&ga_World);
+  _pShell->SetCurrentWorld(&ga_World);
 
   // demo synchronization starts at the beginning initially
   ga_fDemoTimer = 0.0f;
@@ -1562,7 +1554,7 @@ void CNetworkLibrary::StopGame(void)
   ga_aplsPlayers.Clear();
   ga_aplsPlayers.New(NET_MAXLOCALPLAYERS);
   // remember the world pointer
-  _pShell->SetINDEX("pwoCurrentWorld", (INDEX)NULL);
+  _pShell->SetCurrentWorld(NULL);
 
   // rewind the timer
   _pTimer->SetCurrentTick(0.0f);
@@ -1686,8 +1678,7 @@ void CNetworkLibrary::ChangeLevel_internal(void)
     // remember the world filename
     ga_fnmWorld = ga_fnmNextLevel;
     // remember the world pointer
-    STUBBED("64-bit issue");
-    _pShell->SetINDEX("pwoCurrentWorld", (INDEX)(size_t)&ga_World);
+    _pShell->SetCurrentWorld(&ga_World);
   // if there is remembered level
   } else {
     // restore it
@@ -2392,8 +2383,7 @@ extern void NET_MakeDefaultState_t(
     _pNetwork->ga_fnmWorld = fnmWorld;
     _pNetwork->ga_fnmNextLevel = CTString("");
     // remember the world pointer
-    STUBBED("64-bit issue");
-    _pShell->SetINDEX("pwoCurrentWorld", (INDEX)(size_t)&_pNetwork->ga_World);
+    _pShell->SetCurrentWorld(&_pNetwork->ga_World);
 
     // reset random number generator
     _pNetwork->ga_sesSessionState.ResetRND();

--- a/Sources/Engine/Network/SessionState.h
+++ b/Sources/Engine/Network/SessionState.h
@@ -60,7 +60,7 @@ public:
   TIME pe_tmTick;
   ULONG pe_ulEntityID;
   ULONG pe_ulTypeID;
-  ULONG pe_ulEventID;
+  ULONG pe_ulEventID; // FIXME: make this void* or uintptr_t/size_t
 
   CPredictedEvent(void);
   void Clear(void) {};

--- a/Sources/Engine/Templates/BSP.cpp
+++ b/Sources/Engine/Templates/BSP.cpp
@@ -1139,11 +1139,13 @@ void BSPTree<Type, iDimensions>::MoveSubTreeToArray(BSPNode<Type, iDimensions> *
   if (pbnSubtree->bn_pbnFront==NULL) {
     bnInArray.bn_pbnFront = NULL;
   } else {
+    STUBBED("64-bit issue"); // bn_ulPlaneTag is uint32!
     bnInArray.bn_pbnFront = (BSPNode<Type, iDimensions>*)pbnSubtree->bn_pbnFront->bn_ulPlaneTag;
   }
   if (pbnSubtree->bn_pbnBack==NULL) {
     bnInArray.bn_pbnBack = NULL;
   } else {
+    STUBBED("64-bit issue"); // basically the same as above but for back!
     bnInArray.bn_pbnBack = (BSPNode<Type, iDimensions>*)pbnSubtree->bn_pbnBack->bn_ulPlaneTag;
   }
 }

--- a/Sources/Engine/Templates/BSP_internal.h
+++ b/Sources/Engine/Templates/BSP_internal.h
@@ -87,12 +87,12 @@ class BSPEdge {
 public:
   Vector<Type, iDimensions> bed_vVertex0;  // edge vertices
   Vector<Type, iDimensions> bed_vVertex1;
-  ULONG bed_ulEdgeTag;   // tags for BSPs with tagged edges/planes
+  size_t bed_ulEdgeTag;   // tags for BSPs with tagged edges/planes - FIXME DG: or uintprt_t?
 
   /* Default constructor. */
   inline BSPEdge(void) {};
   /* Constructor with two vectors. */
-  inline BSPEdge(const Vector<Type, iDimensions> &vVertex0, const Vector<Type, iDimensions> &vVertex1, ULONG ulTag)
+  inline BSPEdge(const Vector<Type, iDimensions> &vVertex0, const Vector<Type, iDimensions> &vVertex1, size_t ulTag)
     : bed_vVertex0(vVertex0), bed_vVertex1(vVertex1), bed_ulEdgeTag(ulTag) {}
 
   /* Clear the object. */
@@ -110,7 +110,7 @@ template<class Type, int iDimensions>
 class BSPPolygon : public Plane<Type, iDimensions> {
 public:
   CDynamicArray<BSPEdge<Type, iDimensions> > bpo_abedPolygonEdges;  // array of edges in the polygon
-  ULONG bpo_ulPlaneTag;         // tags for BSPs with tagged planes (-1 for no tag)
+  size_t bpo_ulPlaneTag;         // tags for BSPs with tagged planes (-1 for no tag)
 
   /* Add an edge to the polygon. */
   inline void AddEdge(const Vector<Type, iDimensions> &vPoint0, const Vector<Type, iDimensions> &vPoint1, ULONG ulTag);
@@ -119,7 +119,7 @@ public:
   inline BSPPolygon(void) : bpo_ulPlaneTag(-1) {};
   /* Constructor with array of edges and plane. */
   inline BSPPolygon(
-    Plane<Type, iDimensions> &plPlane, CDynamicArray<BSPEdge<Type, iDimensions> > abedPolygonEdges, ULONG ulPlaneTag)
+    Plane<Type, iDimensions> &plPlane, CDynamicArray<BSPEdge<Type, iDimensions> > abedPolygonEdges, size_t ulPlaneTag)
     : Plane<Type, iDimensions>(plPlane)
     , bpo_abedPolygonEdges(abedPolygonEdges)
     , bpo_ulPlaneTag(ulPlaneTag)

--- a/Sources/Entities/WorldBase.es
+++ b/Sources/Entities/WorldBase.es
@@ -86,7 +86,7 @@ EntityStats *FindStats(const CTString &strName)
 static void MakeWorldStatistics(void)
 {
   // get the world pointer
-  CWorld *pwo = (CWorld *)_pShell->GetINDEX("pwoCurrentWorld");
+  CWorld *pwo = _pShell->GetCurrentWorld();
   // if there is no current world
   if (pwo==NULL) {
     CPrintF("No current world.\n");
@@ -152,7 +152,7 @@ static void MakeWorldStatistics(void)
 static void ReoptimizeAllBrushes(void)
 {
   // get the world pointer
-  CWorld *pwo = (CWorld *)_pShell->GetINDEX("pwoCurrentWorld");
+  CWorld *pwo = _pShell->GetCurrentWorld();
   // if there is no current world
   if (pwo==NULL) {
     CPrintF("No current world.\n");

--- a/Sources/EntitiesMP/Common/Particles.cpp
+++ b/Sources/EntitiesMP/Common/Particles.cpp
@@ -1591,7 +1591,7 @@ INDEX Particles_Regeneration(CEntity *pen, FLOAT tmStart, FLOAT tmStop, FLOAT fY
     
     UBYTE ubR = (UBYTE) (192+afStarsPositions[iRnd][1]*64);
     UBYTE ubG = (UBYTE) (192+afStarsPositions[iRnd][2]*64);
-    UBYTE ubB = (UBYTE) (192+afStarsPositions[iRnd][3]*64);
+    UBYTE ubB = (UBYTE) (192+afStarsPositions[iRnd][3]*64); // FIXME DG: afStarsPositions[i][3] invalid, what's going on here?
     UBYTE ubA = (UBYTE) CalculateRatio( fT, 0.0f, 1.0f, 0.4f, 0.01f)*255;
     COLOR colLine = RGBToColor( ubR, ubG, ubB) | ubA;
     

--- a/Sources/EntitiesMP/Common/Particles.cpp
+++ b/Sources/EntitiesMP/Common/Particles.cpp
@@ -1589,9 +1589,10 @@ INDEX Particles_Regeneration(CEntity *pen, FLOAT tmStart, FLOAT tmStop, FLOAT fY
       vPos2 = Lerp( vSource, vDestination, fT2);
     }
     
-    UBYTE ubR = (UBYTE) (192+afStarsPositions[iRnd][1]*64);
-    UBYTE ubG = (UBYTE) (192+afStarsPositions[iRnd][2]*64);
-    UBYTE ubB = (UBYTE) (192+afStarsPositions[iRnd][3]*64); // FIXME DG: afStarsPositions[i][3] invalid, what's going on here?
+    // DG: changed indices from 1-3 to 0-2 so they're not out of bounds
+    UBYTE ubR = (UBYTE) (192+afStarsPositions[iRnd][0]*64);
+    UBYTE ubG = (UBYTE) (192+afStarsPositions[iRnd][1]*64);
+    UBYTE ubB = (UBYTE) (192+afStarsPositions[iRnd][2]*64);
     UBYTE ubA = (UBYTE) CalculateRatio( fT, 0.0f, 1.0f, 0.4f, 0.01f)*255;
     COLOR colLine = RGBToColor( ubR, ubG, ubB) | ubA;
     
@@ -2242,7 +2243,7 @@ void Particles_DustFall(CEntity *pen, FLOAT tmStarted, FLOAT3D vStretch)
     FLOAT fRndAppearX = afStarsPositions[iRnd][0]*vStretch(1);
     FLOAT fRndSpeedY = (afStarsPositions[iRnd][1]+0.5f)*0.125f*vStretch(2);
     FLOAT fRndAppearZ = afStarsPositions[iRnd][2]*vStretch(3);
-    FLOAT3D vRndDir=FLOAT3D(afStarsPositions[iRnd][1],0,afStarsPositions[iRnd][3]);
+    FLOAT3D vRndDir=FLOAT3D(afStarsPositions[iRnd][0],0,afStarsPositions[iRnd][2]);
     vRndDir.Normalize();
     FLOAT fRiseTime=Max(fRatio-0.5f,0.0f);
     FLOAT3D vPos=vCenter+vRndDir*fSpeed*3*fStretch+vY*fRiseTime*0.25f;
@@ -2374,7 +2375,7 @@ void Particles_LavaErupting(CEntity *pen, FLOAT fStretchAll, FLOAT fSize,
   vPos(2) += (fStretchY+(fStretchY*0.25f*afStarsPositions[iRnd1][1]))*fT-fGA/2.0f*fT*fT; 
   vPos(3) += fRndAppearZ+afStarsPositions[iRnd1][2]*fT*fStretchZ*10;
 
-  Particle_RenderSquare( vPos, fSize+afStarsPositions[iRnd2][3]*fSize*0.5f, fRndRotation*300*fT, C_WHITE|CT_OPAQUE);
+  Particle_RenderSquare( vPos, fSize+afStarsPositions[iRnd2][2]*fSize*0.5f, fRndRotation*300*fT, C_WHITE|CT_OPAQUE);
 
   // all done
   Particle_Flush();
@@ -3091,7 +3092,7 @@ void Particles_Rain(CEntity *pen, FLOAT fGridSize, INDEX ctGrids, FLOAT fFactor,
   for( INDEX iZ=0; iZ<ctGrids; iZ++)
   {
     INDEX iRndZ = (ULONG(vPos(3)+iZ)) % CT_MAX_PARTICLES_TABLE;
-    FLOAT fZOrg = vPos(3) + (iZ+afStarsPositions[iRndZ][3])*fGridSize;
+    FLOAT fZOrg = vPos(3) + (iZ+afStarsPositions[iRndZ][2])*fGridSize;
     for( INDEX iX=0; iX<ctGrids; iX++)
     {
 
@@ -3200,12 +3201,12 @@ void Particles_Snow(CEntity *pen, FLOAT fGridSize, INDEX ctGrids, FLOAT fFactor,
       FLOAT vYStart=vPos(2)+YGRIDS_VISIBLE_ABOVE*YGRID_SIZE+fD;
 
       INDEX iDanceRnd=(iRndXZ+2)%CT_MAX_PARTICLES_TABLE;
-      FLOAT fDanceAngle=afStarsPositions[iDanceRnd][1]*360.0f;
-      FLOAT fAmpX=afStarsPositions[iDanceRnd][2]*2.0f;
-      FLOAT fAmpZ=afStarsPositions[iDanceRnd][3]*2.0f;
-      FLOAT fX = vPos(1) + (iX+afStarsPositions[iRndXZ][3])*fGridSize+fAmpX*sin(fDanceAngle+fNow*3.0f);
-      FLOAT fZ = vPos(3) + (iZ+afStarsPositions[iRndXZ][2])*fGridSize+fAmpZ*cos(fDanceAngle+fNow*3.0f);
-      FLOAT fT0 = afStarsPositions[(INDEX(2+Abs(fX)+Abs(fZ))*262147) % CT_MAX_PARTICLES_TABLE][2];
+      FLOAT fDanceAngle=afStarsPositions[iDanceRnd][0]*360.0f;
+      FLOAT fAmpX=afStarsPositions[iDanceRnd][1]*2.0f;
+      FLOAT fAmpZ=afStarsPositions[iDanceRnd][2]*2.0f;
+      FLOAT fX = vPos(1) + (iX+afStarsPositions[iRndXZ][2])*fGridSize+fAmpX*sin(fDanceAngle+fNow*3.0f);
+      FLOAT fZ = vPos(3) + (iZ+afStarsPositions[iRndXZ][1])*fGridSize+fAmpZ*cos(fDanceAngle+fNow*3.0f);
+      FLOAT fT0 = afStarsPositions[(INDEX(2+Abs(fX)+Abs(fZ))*262147) % CT_MAX_PARTICLES_TABLE][1];
 
       for( INDEX iY=0; iY<(YGRIDS_VISIBLE_ABOVE+YGRIDS_VISIBLE_BELOW); iY++)
       {
@@ -3618,7 +3619,7 @@ void Particles_BulletSpray(INDEX iRndBase, FLOAT3D vSource, FLOAT3D vGDir, enum 
       afStarsPositions[ iSpray+iRnd][0]*3.0f* fConeMultiplier,
       (afStarsPositions[ iSpray+iRnd][1]+1.0f)*3.0f,
       afStarsPositions[ iSpray+iRnd][2]*3.0f* fConeMultiplier);
-    FLOAT fSpeedRnd = fSpeedStart+afStarsPositions[ iSpray+iRnd*2][3];
+    FLOAT fSpeedRnd = fSpeedStart+afStarsPositions[ iSpray+iRnd*2][2];
     FLOAT3D vPos = vSource + (vDirection+vRandomAngle)*(fT*fSpeedRnd)+vGDir*(fT*fT*fGA);
 
     if( (eptType == EPT_BULLET_WATER) && (vPos(2) < vSource(2)) )
@@ -3756,7 +3757,7 @@ void Particles_EmptyShells( CEntity *pen, ShellLaunchData *asldData)
         FLOAT fXF = cos( afStarsPositions[iRnd+2][0]*PI);
 
         FLOAT fAmpl = ClampUp( fT+afStarsPositions[iRnd+1][1]+0.5f, 2.0f)/64;
-        FLOAT fFormulae =  fAmpl * sin(afStarsPositions[iRnd][2]+fT*afStarsPositions[iRnd][3]*2);
+        FLOAT fFormulae =  fAmpl * sin(afStarsPositions[iRnd][1]+fT*afStarsPositions[iRnd][2]*2);
 
         FLOAT fColorFactor = 1.0f;
         if( fT>fLife/2)
@@ -4781,11 +4782,11 @@ void Particles_AfterBurner(CEntity *pen, FLOAT tmSpawn, FLOAT fStretch, INDEX iG
     // smoke
     FLOAT3D vPosS = *pvPos1;
     Particle_SetTexturePart( 512, 512, 1, 0);
-    FLOAT fAngleS = afStarsPositions[iRnd][2]*360.0f+fT*120.0f*afStarsPositions[iRnd][3];
+    FLOAT fAngleS = afStarsPositions[iRnd][1]*360.0f+fT*120.0f*afStarsPositions[iRnd][2];
     FLOAT fSizeS = (0.5f+aSmoke_sol[iIndex]*2.5f)*fStretch;
-    FLOAT3D vVelocityS=FLOAT3D(afStarsPositions[iRnd][2], 
-                               afStarsPositions[iRnd][3],
-                               afStarsPositions[iRnd][1])*5.0f;
+    FLOAT3D vVelocityS=FLOAT3D(afStarsPositions[iRnd][1],
+                               afStarsPositions[iRnd][2],
+                               afStarsPositions[iRnd][0])*5.0f;
     vPosS=vPosS+vVelocityS*fT+vGDir*fGA/2.0f*(fT*fT)/32.0f;
     Particle_RenderSquare( vPosS, fSizeS, fAngleS, ByteSwap(pcolSmoke[iIndex]));
 
@@ -4899,7 +4900,7 @@ void Particles_RocketMotorBurning(CEntity *pen, FLOAT tmSpawn, FLOAT3D vStretch,
     INDEX iIndex=(INDEX) (fT*255);
     // smoke
     Particle_SetTexturePart( 512, 512, 1, 0);
-    FLOAT fAngleS = afStarsPositions[iRnd][2]*360.0f+fT*120.0f*afStarsPositions[iRnd][3];
+    FLOAT fAngleS = afStarsPositions[iRnd][1]*360.0f+fT*120.0f*afStarsPositions[iRnd][2];
     FLOAT fSizeS = (3.0f+fT*4.5f)*fStretch;
     Particle_RenderSquare( vPosS, fSizeS, fAngleS, ByteSwap(pcolSmoke[iIndex]));
 
@@ -4933,7 +4934,7 @@ void Particles_RocketMotorBurning(CEntity *pen, FLOAT tmSpawn, FLOAT3D vStretch,
     INDEX iIndex=(INDEX) (fT*255);
     // smoke
     Particle_SetTexturePart( 512, 512, 1, 0);
-    FLOAT fAngleS = afStarsPositions[iRnd][2]*360.0f+fT*120.0f*afStarsPositions[iRnd][3];
+    FLOAT fAngleS = afStarsPositions[iRnd][1]*360.0f+fT*120.0f*afStarsPositions[iRnd][2];
     FLOAT fSizeS = (1.5f+aSmoke_sol[iIndex]*2.5f)*fStretch*fFireStretch;
     Particle_RenderSquare( vPosS, fSizeS, fAngleS, ByteSwap(pcolSmoke[iIndex]));
 
@@ -5303,7 +5304,7 @@ void Particles_CollectEnergy(CEntity *pen, FLOAT tmStart, FLOAT tmStop)
 
     UBYTE ubR = (UBYTE) (255);//+afStarsPositions[iRnd][1]*64;
     UBYTE ubG = (UBYTE) (128+(1.0f-fT)*128);//223+afStarsPositions[iRnd][2]*64;
-    UBYTE ubB = (UBYTE) (16+afStarsPositions[iRnd][3]*32+(1.0f-fT)*64);
+    UBYTE ubB = (UBYTE) (16+afStarsPositions[iRnd][2]*32+(1.0f-fT)*64);
     UBYTE ubA = (UBYTE) (CalculateRatio( fT, 0.0f, 1.0f, 0.4f, 0.01f)*255);
     COLOR colLine = RGBToColor( ubR, ubG, ubB) | ubA;
     
@@ -5339,7 +5340,7 @@ void Particles_CollectEnergy(CEntity *pen, FLOAT tmStart, FLOAT tmStop)
       vZ*Cos(fT*360.0f)*fRadius;
     UBYTE ubR = (UBYTE) (255);
     UBYTE ubG = (UBYTE) (128+(1.0f-fT)*128);
-    UBYTE ubB = (UBYTE) (16+afStarsPositions[iRnd][3]*32+(1.0f-fT)*64);
+    UBYTE ubB = (UBYTE) (16+afStarsPositions[iRnd][2]*32+(1.0f-fT)*64);
     FLOAT fFader=CalculateRatio( fT, 0.0f, 1.0f, 0.4f, 0.01f);
     FLOAT fPulser=(1.0f+(sin((fT*fT)/4.0f)))/2.0f;
     UBYTE ubA = (UBYTE) (fFader*fPulser*255);
@@ -5404,9 +5405,9 @@ void Particles_SummonerDisappear( CEntity *pen, FLOAT tmStart)
   for( INDEX iVtx=0; iVtx<ctVtx; iVtx+=1)
   {
     INDEX iRnd=iVtx%CT_MAX_PARTICLES_TABLE;
-    FLOAT fRndPulseOffset=afStarsPositions[iRnd][1];
-    FLOAT fRndPulseSpeed=afStarsPositions[iRnd][2]*128.0f;
-    FLOAT fRndSize=afStarsPositions[iRnd][3];
+    FLOAT fRndPulseOffset=afStarsPositions[iRnd][0];
+    FLOAT fRndPulseSpeed=afStarsPositions[iRnd][1]*128.0f;
+    FLOAT fRndSize=afStarsPositions[iRnd][2];
 
     FLOAT fPulser=1.0f-(fRatio*(1.0f+(Sin(fRatio*360.0f*fRndPulseSpeed+fRndPulseOffset*360.0f)))/2.0f);
     UBYTE ubColor = UBYTE(CT_OPAQUE*fColorFactor*fPulser);
@@ -5720,7 +5721,7 @@ void Particles_LarvaEnergy(CEntity *pen, FLOAT3D vOffset)
 
     UBYTE ubR = (UBYTE) (255);//+afStarsPositions[iRnd][1]*64;
     UBYTE ubG = (UBYTE) (128+(1.0f-fT)*128);//223+afStarsPositions[iRnd][2]*64;
-    UBYTE ubB = (UBYTE) (16+afStarsPositions[iRnd][3]*32+(1.0f-fT)*64);
+    UBYTE ubB = (UBYTE) (16+afStarsPositions[iRnd][2]*32+(1.0f-fT)*64);
     UBYTE ubA = (UBYTE) (CalculateRatio( fT, 0.0f, 1.0f, 0.4f, 0.01f)*255);
     COLOR colLine = RGBToColor( ubR, ubG, ubB) | ubA;
     
@@ -5756,7 +5757,7 @@ void Particles_LarvaEnergy(CEntity *pen, FLOAT3D vOffset)
       vZ*Cos(fT*360.0f)*fRadius;
     UBYTE ubR = (UBYTE) (255);
     UBYTE ubG = (UBYTE) (128+(1.0f-fT)*128);
-    UBYTE ubB = (UBYTE) (16+afStarsPositions[iRnd][3]*32+(1.0f-fT)*64);
+    UBYTE ubB = (UBYTE) (16+afStarsPositions[iRnd][2]*32+(1.0f-fT)*64);
     FLOAT fFader=CalculateRatio( fT, 0.0f, 1.0f, 0.4f, 0.01f);
     FLOAT fPulser=(1.0f+(sin((fT*fT)/4.0f)))/2.0f;
     UBYTE ubA = (UBYTE) (fFader*fPulser*255);
@@ -5854,7 +5855,7 @@ void Particles_ModelGlow( CEntity *pen, FLOAT tmEnd, enum ParticleTexture ptText
   for( INDEX iVtx=0; iVtx<ctVtx-1; iVtx+=(INDEX)iVtxStep)
   {
     INDEX iRnd=iVtx%CT_MAX_PARTICLES_TABLE;
-    FLOAT fRndSize=afStarsPositions[iRnd][3];
+    FLOAT fRndSize=afStarsPositions[iRnd][2];
 
     FLOAT3D vPos = avVertices[iVtx];
     Particle_RenderSquare( vPos, (1.0f+fRndSize)*fSize, 0, iCol|ubCol);    
@@ -5895,7 +5896,7 @@ void Particles_ModelGlow2( CModelObject *mo, CPlacement3D pl, FLOAT tmEnd, enum 
   for( INDEX iVtx=0; iVtx<ctVtx-1; iVtx+=(INDEX)iVtxStep)
   {
     INDEX iRnd=iVtx%CT_MAX_PARTICLES_TABLE;
-    FLOAT fRndSize=afStarsPositions[iRnd][3];
+    FLOAT fRndSize=afStarsPositions[iRnd][2];
 
     FLOAT3D vPos = avVertices[iVtx];
     Particle_RenderSquare( vPos, (1.0f+fRndSize)*fSize, 0, iCol|ubCol);    
@@ -5977,11 +5978,11 @@ void Particles_RunAfterBurner(CEntity *pen, FLOAT tmEnd, FLOAT fStretch, INDEX i
     // smoke
     FLOAT3D vPosS = *pvPos1;
     Particle_SetTexturePart( 512, 512, 1, 0);
-    FLOAT fAngleS = afStarsPositions[iRnd][2]*360.0f+fT*120.0f*afStarsPositions[iRnd][3];
+    FLOAT fAngleS = afStarsPositions[iRnd][1]*360.0f+fT*120.0f*afStarsPositions[iRnd][2];
     FLOAT fSizeS = (0.5f+aSmoke_sol[iIndex]*2.5f)*fStretch;
-    FLOAT3D vVelocityS=FLOAT3D(afStarsPositions[iRnd][2], 
-                               afStarsPositions[iRnd][3],
-                               afStarsPositions[iRnd][1])*5.0f;
+    FLOAT3D vVelocityS=FLOAT3D(afStarsPositions[iRnd][1],
+                               afStarsPositions[iRnd][2],
+                               afStarsPositions[iRnd][0])*5.0f;
     vPosS=vPosS+vVelocityS*fT+vGDir*fGA/2.0f*(fT*fT)/32.0f;
     col = ByteSwap(pcolSmoke[iIndex]);
     col = (col&0xffffff00)|((col&0x000000ff)*ubColMul/255);

--- a/Sources/EntitiesMP/WorldBase.es
+++ b/Sources/EntitiesMP/WorldBase.es
@@ -64,7 +64,7 @@ EntityStats *FindStats(const CTString &strName)
 static void MakeWorldStatistics(void)
 {
   // get the world pointer
-  CWorld *pwo = (CWorld *)_pShell->GetINDEX("pwoCurrentWorld");
+  CWorld *pwo = _pShell->GetCurrentWorld();
   // if there is no current world
   if (pwo==NULL) {
     CPrintF("No current world.\n");
@@ -130,7 +130,7 @@ static void MakeWorldStatistics(void)
 static void ReoptimizeAllBrushes(void)
 {
   // get the world pointer
-  CWorld *pwo = (CWorld *)_pShell->GetINDEX("pwoCurrentWorld");
+  CWorld *pwo = _pShell->GetCurrentWorld();
   // if there is no current world
   if (pwo==NULL) {
     CPrintF("No current world.\n");
@@ -157,7 +157,7 @@ static void DoLevelSafetyChecks()
   CPrintF("\n****  BEGIN Level safety checking  ****\n\n");
   
   // get the world pointer
-  CWorld *pwo = (CWorld *)_pShell->GetINDEX("pwoCurrentWorld");
+  CWorld *pwo = _pShell->GetCurrentWorld();
   // if there is no current world
   if (pwo==NULL) {
     CPrintF("Error - no current world.\n");

--- a/Sources/GameMP/Controls.cpp
+++ b/Sources/GameMP/Controls.cpp
@@ -227,9 +227,10 @@ void CControls::Load_t( CTFileName fnFile)
       achrActionName[ 0] = 0;
       FLOAT fSensitivity = 50;
       FLOAT fDeadZone = 0;
-      // FIXME DG: gcc and clang say the followign has too many arguments for the given format
+      // FIXME DG: if achrIfSmooth should be read, add another %1024s - but it seems like achrIfSmooth
+      //           is unused - below achrIfRelative is compared to "Smooth"?!
       sscanf( achrLine, "%*[^\"]\"%1024[^\"]\"%*[^\"]\"%1024[^\"]\" %g %g %1024s %1024s",
-              achrActionName, achrAxis, &fSensitivity, &fDeadZone,   achrIfInverted, achrIfRelative, achrIfSmooth);
+              achrActionName, achrAxis, &fSensitivity, &fDeadZone, achrIfInverted, achrIfRelative /*, achrIfSmooth*/);
       // find action axis
       INDEX iActionAxisNo = -1;
       {for( INDEX iAxis=0; iAxis<AXIS_ACTIONS_CT; iAxis++){

--- a/Sources/GameMP/Controls.cpp
+++ b/Sources/GameMP/Controls.cpp
@@ -227,8 +227,9 @@ void CControls::Load_t( CTFileName fnFile)
       achrActionName[ 0] = 0;
       FLOAT fSensitivity = 50;
       FLOAT fDeadZone = 0;
+      // FIXME DG: gcc and clang say the followign has too many arguments for the given format
       sscanf( achrLine, "%*[^\"]\"%1024[^\"]\"%*[^\"]\"%1024[^\"]\" %g %g %1024s %1024s",
-              achrActionName, achrAxis, &fSensitivity, &fDeadZone, achrIfInverted, achrIfRelative, achrIfSmooth);
+              achrActionName, achrAxis, &fSensitivity, &fDeadZone,   achrIfInverted, achrIfRelative, achrIfSmooth);
       // find action axis
       INDEX iActionAxisNo = -1;
       {for( INDEX iAxis=0; iAxis<AXIS_ACTIONS_CT; iAxis++){

--- a/Sources/SeriousSam/Menu.cpp
+++ b/Sources/SeriousSam/Menu.cpp
@@ -1187,7 +1187,7 @@ void JoinNetworkGame(void)
       _pNetwork->ga_strRequiredMod.ScanF("%250[^\\]\\%s", &strModName, &strModURL);
       _fnmModSelected = CTString(strModName);
       _strModURLSelected = strModURL;
-      if (_strModURLSelected="") {
+      if (_strModURLSelected="") { // FIXME DG: not == ?
         _strModURLSelected = "http://www.croteam.com/mods/Old";
       }
       _strModServerSelected.PrintF("%s:%s", (const char *) _pGame->gam_strJoinAddress, (const char *) _pShell->GetValue("net_iPort"));

--- a/Sources/SeriousSam/Menu.cpp
+++ b/Sources/SeriousSam/Menu.cpp
@@ -1187,7 +1187,7 @@ void JoinNetworkGame(void)
       _pNetwork->ga_strRequiredMod.ScanF("%250[^\\]\\%s", &strModName, &strModURL);
       _fnmModSelected = CTString(strModName);
       _strModURLSelected = strModURL;
-      if (_strModURLSelected="") { // FIXME DG: not == ?
+      if (_strModURLSelected=="") {
         _strModURLSelected = "http://www.croteam.com/mods/Old";
       }
       _strModServerSelected.PrintF("%s:%s", (const char *) _pGame->gam_strJoinAddress, (const char *) _pShell->GetValue("net_iPort"));

--- a/Sources/WorldEditor/WorldEditor.cpp
+++ b/Sources/WorldEditor/WorldEditor.cpp
@@ -2098,7 +2098,7 @@ BOOL CWorldEditorApp::OnIdle(LONG lCount)
     if (pvCurrent!=NULL) {
       CWorldEditorDoc *pdocCurrent = pvCurrent->GetDocument();
       if (pdocCurrent!=NULL) {
-        _pShell->SetINDEX("pwoCurrentWorld", (INDEX)&pdocCurrent->m_woWorld);
+        _pShell->SetCurrentWorld(&pdocCurrent->m_woWorld);
       }
     }
 


### PR DESCRIPTION
This should fix some more 64bit issues.

I also added some more FIXMEs and STUBBED("64-but issue") where the compiler gave me corresponding warnings.

I was able to play the complete first level of the second encounter, however I think there's still a lot missing.

Does anyone know what `CShell::GetINDEX()` is about? Its return value often is casted to pointer and dereferenced directly afterwards (e.g. in Engine/Network/Network.cpp `CacheShadows()`; I didn't mark all occurences in the code).
Is there some kind of trick (like in `ModelPolygonVertex::Read_t()` where the "pointers" are actually indexes that are later converted back to pointers) that I'm missing? I'm surprised that INDEX is used to store a pointer there, not ULONG like in several other places..
