### PR TITLE
fix build on gcc 4.8

### DIFF
--- a/Sources/Engine/Graphics/Graphics.cpp
+++ b/Sources/Engine/Graphics/Graphics.cpp
@@ -663,6 +663,9 @@ static inline void IncrementByteWithClip( UBYTE &ub, SLONG slAdd)
 #endif
 
 // performs dithering of a 32-bit bipmap (can be in-place)
+#ifdef __GNUC__
+__attribute__((noinline)) // because of asm labels
+#endif
 void DitherBitmap( INDEX iDitherType, ULONG *pulSrc, ULONG *pulDst, PIX pixWidth, PIX pixHeight,
                    PIX pixCanvasWidth, PIX pixCanvasHeight)
 {


### PR DESCRIPTION
some versions of gcc want to inline DitherBitmap(), and this leads to trouble:
Sources/Engine/Graphics/Graphics.cpp:1167: Error: symbol `rowLoopE' is already defined
Sources/Engine/Graphics/Graphics.cpp:1170: Error: symbol`pixLoopEL' is already defined
...
