### PR TITLE
bswap_32() is a linuxism, use inline code instead.

### DIFF
--- a/Sources/Engine/Graphics/Fog.cpp
+++ b/Sources/Engine/Graphics/Fog.cpp
@@ -25,9 +25,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <Engine/Graphics/Fog_internal.h>
 #include <Engine/Graphics/GfxProfile.h>
 #include <Engine/Graphics/ImageInfo.h>
-#ifdef USE_PORTABLE_C
-# include <byteswap.h>  
-#endif
 
 // asm shortcuts
 #define O offset
@@ -75,7 +72,8 @@ ULONG PrepareTexture( UBYTE *pubTexture, PIX pixSizeI, PIX pixSizeJ)
    DWORD* dst = (DWORD*)(pubTexture+pixTextureSize);
    for (int i=0; i<pixTextureSize; i++) {
     const DWORD tmp = ((DWORD)*src) | 0xFFFFFF00;
-    *dst = bswap_32(tmp);
+    *dst = ((tmp << 24) & 0xff000000 ) | ((tmp <<  8) & 0x00ff0000 ) |
+      ((tmp >>  8) & 0x0000ff00 ) | ((tmp >> 24) & 0x000000ff );
     src++;
     dst++;
    }


### PR DESCRIPTION
bwap_32() is a function specific to Linux, unavailable on FreeBSD and OSX. Instead of messing with other platform specific functions, #ifdef and so on provide a fast inline implementation.
