### PR TITLE
Fix for FloatToInt

### DIFF
--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -112,9 +112,20 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
 	# TODO fix these warnings
 	add_compile_options(-Wno-sign-compare)
 	add_compile_options(-Wno-switch)
-	add_compile_options(-Wno-format-security)
-	add_definitions(-Wno-logical-op-parentheses)
-	MESSAGE(WARNING, "re-enable -Wlogical-op-parentheses some day!")
+	add_compile_options(-Wno-unknown-pragmas)
+	add_compile_options(-Wno-unused-variable)
+	add_compile_options(-Wno-unused-value)
+	add_compile_options(-Wno-reorder)
+	add_compile_options(-Wno-unused-but-set-variable)
+	add_compile_options(-Wno-parentheses)
+	MESSAGE(WARNING, "re-enable some of the warnings some day!")
+
+	if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")
+		# !!! FIXME: turn a bunch of these off, this is just for now. I hope.  --ryan.
+		add_compile_options(-Wno-tautological-undefined-compare)
+		add_compile_options(-Wno-c++11-compat-deprecated-writable-strings)
+		add_compile_options(-Wno-logical-op-parentheses) # FIXME: this too should be re-enabled
+	endif()
 
 	if(MACOSX)
 		add_definitions(-DPLATFORM_UNIX=1)
@@ -149,16 +160,6 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
 	if(CMAKE_COMPILER_IS_GNUCC)
 	    	# !!! FIXME: turn a bunch of these off, this is just for now. I hope.  --ryan.
     		add_compile_options(-Wno-invalid-offsetof)
-	endif()
-	
-	if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    		# !!! FIXME: turn a bunch of these off, this is just for now. I hope.  --ryan.
-    		add_compile_options(-Wno-unused-value)
-    		add_compile_options(-Wno-switch)
-    		add_compile_options(-Wno-tautological-undefined-compare)
-		add_compile_options(-Wno-c++11-compat-deprecated-writable-strings)
-		add_definitions(-Wno-logical-op-parentheses)
-    		MESSAGE(WARNING "reenable -Wlogical-op-parentheses some day!")	
 	endif()
 
 elseif(MSVC) # RAKE! I don't know if this will build with MSVC

--- a/Sources/Engine/Math/Functions.h
+++ b/Sources/Engine/Math/Functions.h
@@ -314,8 +314,7 @@ inline SLONG FloatToInt( FLOAT f)
 {
 #if defined(__arm__) || defined(USE_PORTABLE_C)
   // round to nearest by adding/subtracting 0.5 (depending on f pos/neg) before converting to SLONG
-  float addToRound = 0.5f;
-  copysignf(addToRound, f); // copy f's signbit to addToRound => if f<0 then addToRound = -addToRound
+  float addToRound = copysignf(0.5f, f); // copy f's signbit to 0.5 => if f<0 then addToRound = -0.5, else 0.5
   return((SLONG) (f + addToRound));
 
 #elif (defined __MSVC_INLINE__)


### PR DESCRIPTION
I screwed up handling negative numbers. Oops.
Luckily GCC told me about it (only used clang before).

Also improved warning suppression in cmake a bit.
