### PR TITLE
Fix ModEXT.txt issues

### DIFF
--- a/ModExt.txt
+++ b/ModExt.txt
@@ -1,1 +1,0 @@
-ModEXT.txt

--- a/Sources/Engine/Base/Stream.cpp
+++ b/Sources/Engine/Base/Stream.cpp
@@ -169,7 +169,7 @@ void InitStreams(void)
   }
   // find eventual extension for the mod's dlls
   _strModExt = "";
-  LoadStringVar(CTString("ModExt.txt"), _strModExt);
+  LoadStringVar(CTString("ModEXT.txt"), _strModExt);
 
 
   CPrintF(TRANSV("Loading group files...\n"));


### PR DESCRIPTION
Creating a ModExt.txt symlink to ModEXT.txt is a bad idea for filesystems that does not support files having the same name with different casing. symlink is also not compatible with Windows anyway.

Instead the root of the problem is fixed by modifying the code to load the correct file.
