### PR TITLE
Fix crashes from this!=NULL removal

### DIFF
--- a/Sources/Engine/Base/Anim.cpp
+++ b/Sources/Engine/Base/Anim.cpp
@@ -615,7 +615,7 @@ CAnimObject::CAnimObject(void)
 /* Destructor. */
 CAnimObject::~CAnimObject(void)
 {
-  ao_AnimData->RemReference();
+  if(ao_AnimData != NULL) ao_AnimData->RemReference();
 }
 
 // copy from another object of same class
@@ -818,9 +818,9 @@ BOOL CAnimObject::IsUpToDate(const CUpdateable &ud) const
 void CAnimObject::SetData(CAnimData *pAD)
 {
   // mark new data as referenced once more
-  pAD->AddReference();
+  if(pAD != NULL) pAD->AddReference();
   // mark old data as referenced once less
-  ao_AnimData->RemReference();
+  if(ao_AnimData != NULL) ao_AnimData->RemReference();
   // remember new data
   ao_AnimData = pAD;
   if( pAD != NULL) StartAnim( 0);

--- a/Sources/Engine/Base/Stream.cpp
+++ b/Sources/Engine/Base/Stream.cpp
@@ -169,7 +169,13 @@ void InitStreams(void)
   }
   // find eventual extension for the mod's dlls
   _strModExt = "";
-  LoadStringVar(CTString("ModEXT.txt"), _strModExt);
+  // DG: apparently both ModEXT.txt and ModExt.txt exist in the wild.
+  CTFileName tmp;
+  if(ExpandFilePath(EFP_READ, CTString("ModEXT.txt"), tmp) != EFP_NONE) {
+    LoadStringVar(CTString("ModEXT.txt"), _strModExt);
+  } else {
+    LoadStringVar(CTString("ModExt.txt"), _strModExt);
+  }
 
 
   CPrintF(TRANSV("Loading group files...\n"));

--- a/Sources/Engine/Entities/Entity.cpp
+++ b/Sources/Engine/Entities/Entity.cpp
@@ -186,7 +186,7 @@ CEntity::~CEntity(void)
   }
   // clear entity type
   en_RenderType = RT_NONE;
-  en_pecClass->RemReference();
+  if(en_pecClass != NULL) en_pecClass->RemReference();
   en_pecClass = NULL;
 
   en_fSpatialClassificationRadius = -1.0f;

--- a/Sources/Engine/Entities/Entity.h
+++ b/Sources/Engine/Entities/Entity.h
@@ -670,20 +670,20 @@ BOOL ENGINE_API IsDerivedFromClass(CEntity *pen, const char *pstrClassName);
 
 // all standard smart pointer functions are here as inlines
 inline CEntityPointer::CEntityPointer(void) : ep_pen(NULL) {};
-inline CEntityPointer::~CEntityPointer(void) { ep_pen->RemReference(); };
+inline CEntityPointer::~CEntityPointer(void) { if(ep_pen != NULL) ep_pen->RemReference(); };
 inline CEntityPointer::CEntityPointer(const CEntityPointer &penOther) : ep_pen(penOther.ep_pen) {
-  ep_pen->AddReference(); };
+  if(ep_pen != NULL) ep_pen->AddReference(); };
 inline CEntityPointer::CEntityPointer(CEntity *pen) : ep_pen(pen) {
-  ep_pen->AddReference(); };
+  if(ep_pen != NULL) ep_pen->AddReference(); };
 inline const CEntityPointer &CEntityPointer::operator=(CEntity *pen) {
-  pen->AddReference();    // must first add, then remove!
-  ep_pen->RemReference();
+  if(pen != NULL) pen->AddReference();    // must first add, then remove!
+  if(ep_pen != NULL) ep_pen->RemReference();
   ep_pen = pen;
   return *this;
 }
 inline const CEntityPointer &CEntityPointer::operator=(const CEntityPointer &penOther) {
-  penOther.ep_pen->AddReference();    // must first add, then remove!
-  ep_pen->RemReference();
+  if(penOther.ep_pen != NULL) penOther.ep_pen->AddReference();    // must first add, then remove!
+  if(ep_pen != NULL) ep_pen->RemReference();
   ep_pen = penOther.ep_pen;
   return *this;
 }

--- a/Sources/Engine/Graphics/GfxLibrary.cpp
+++ b/Sources/Engine/Graphics/GfxLibrary.cpp
@@ -807,7 +807,7 @@ extern BOOL ProbeMode( CTimerValue tvLast)
 extern void UncacheShadows(void)
 {
   // mute all sounds
-  _pSound->Mute();
+  if(_pSound != NULL) _pSound->Mute();
   // prepare new saturation factors for shadowmaps
   gfx_fSaturation  = ClampDn( gfx_fSaturation, 0.0f); 
   shd_fSaturation  = ClampDn( shd_fSaturation, 0.0f); 

--- a/Sources/Engine/Sound/SoundObject.cpp
+++ b/Sources/Engine/Sound/SoundObject.cpp
@@ -240,9 +240,9 @@ void CSoundObject::Play_internal( CSoundData *pCsdLink, SLONG slFlags)
   Stop_internal();
 
   // mark new data as referenced once more
-  pCsdLink->AddReference();
+  if(pCsdLink != NULL) pCsdLink->AddReference();
   // mark old data as referenced once less
-  so_pCsdLink->RemReference();
+  if(so_pCsdLink != NULL) so_pCsdLink->RemReference();
 
   // store init SoundData
   so_pCsdLink = pCsdLink;


### PR DESCRIPTION
mostly checks before calling AddReference()/RemReference() so far.

this should fix #55 

I haven't experienced any further crashes, but I only started the first level and played 2 minutes, so there may be more.
