### PR TITLE
fix sscanf stack buffer overflow. string should have '\0'

### DIFF
--- a/Sources/GameMP/Controls.cpp
+++ b/Sources/GameMP/Controls.cpp
@@ -180,7 +180,7 @@ void CControls::Load_t( CTFileName fnFile)
   char achrLine[ 1024];
   char achrName[ 1024];
   char achrID[ 1024];
-  char achrActionName[ 1024];
+  char achrActionName[ 1025];
   
   // open script file for reading
   CTFileStream strmFile;
@@ -216,13 +216,13 @@ void CControls::Load_t( CTFileName fnFile)
 
     // if this is axis action
     } else if( CTString( achrID) == "Axis") {
-      char achrAxis[ 1024];
+      char achrAxis[ 1025];
       achrAxis[ 0] = 0;
-      char achrIfInverted[ 1024];
+      char achrIfInverted[ 1025];
       achrIfInverted[ 0] = 0;
-      char achrIfRelative[ 1024];
+      char achrIfRelative[ 1025];
       achrIfRelative[ 0] = 0;
-      //char achrIfSmooth[ 1024];
+      //char achrIfSmooth[ 1025];
       //achrIfSmooth[ 0] = 0;
       achrActionName[ 0] = 0;
       FLOAT fSensitivity = 50;


### PR DESCRIPTION
string didn't allocate '\0' space
reported by clang. 
