### PR TITLE
avoid assert when 640x480 resolution not found

### DIFF
--- a/Sources/SeriousSam/Menu.cpp
+++ b/Sources/SeriousSam/Menu.cpp
@@ -1926,10 +1926,8 @@ static void SizeToResolution(PIX pixSizeI, PIX pixSizeJ, INDEX &iRes)
       return;
     }
   }
-  // if still none found
-  ASSERT(FALSE);  // this should never happen
-  // return first one
-  iRes = 0;
+  // return last one (lowest resolution)
+  iRes = _ctResolutions-1;
 }
 
 


### PR DESCRIPTION
original code search 640x480 as fallback resolution, and crash if not found,
but this resolution is not always avaible. this fix just return last resolution (which is lowest).
this may fix #60 (not confirmed)
